### PR TITLE
hanabiをIDごとに取得するAPIを実装しました

### DIFF
--- a/controller/comment_controller.go
+++ b/controller/comment_controller.go
@@ -1,0 +1,54 @@
+package controller
+
+import (
+	"gin-fleamarket/dto"
+	"gin-fleamarket/models"
+	"gin-fleamarket/services"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+type ICommentController interface {
+	Create(ctx *gin.Context)
+}
+
+type CommentController struct {
+	service services.ICommentService
+}
+
+func NewCommentController(service services.ICommentService) ICommentController {
+	return &CommentController{service: service}
+}
+
+func (c *CommentController) Create(ctx *gin.Context) {
+	user, exists := ctx.Get("user")
+	if !exists {
+		ctx.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+
+	var input dto.CreateCommentInput
+	if err := ctx.ShouldBindJSON(&input); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	userId := user.(*models.User).ID
+
+	hanabiId, err := strconv.ParseUint(ctx.Param("hanabiId"), 10, 64)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id "})
+		return
+	}
+
+	newComment, err := c.service.Create(input, userId, uint(hanabiId))
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, gin.H{"data": newComment})
+
+}

--- a/controller/hanabi_controller.go
+++ b/controller/hanabi_controller.go
@@ -68,7 +68,7 @@ func (c *HanabiController) FindByID(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, gin.H{"founded item": foundedItem})
+	ctx.JSON(http.StatusOK, gin.H{"founded hanabi": foundedItem})
 }
 
 func (c *HanabiController) Create(ctx *gin.Context) {

--- a/dto/comment_dto.go
+++ b/dto/comment_dto.go
@@ -1,0 +1,5 @@
+package dto
+
+type CreateCommentInput struct {
+	Content string `json:"content" binding:"required,max=100"`
+}

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func setupRouter(db *gorm.DB) *gin.Engine {
 	hanabiController := controller.NewHanabiController(hanabiService)
 
 	commentRepository := reposotories.NewCommentMemoryRepository(db)
-	commentService := services.NewCommentService(commentRepository)
+	commentService := services.NewCommentService(commentRepository, hanabiRepository)
 	commentController := controller.NewCommentController(commentService)
 
 	r := gin.Default()

--- a/main.go
+++ b/main.go
@@ -27,6 +27,10 @@ func setupRouter(db *gorm.DB) *gin.Engine {
 	hanabiService := services.NewHanabiService(hanabiRepository)
 	hanabiController := controller.NewHanabiController(hanabiService)
 
+	commentRepository := reposotories.NewCommentMemoryRepository(db)
+	commentService := services.NewCommentService(commentRepository)
+	commentController := controller.NewCommentController(commentService)
+
 	r := gin.Default()
 	r.Use(cors.Default())
 
@@ -47,6 +51,10 @@ func setupRouter(db *gorm.DB) *gin.Engine {
 	hanabiRouterWithAuth.POST("/create", hanabiController.Create)
 	hanabiRouterWithAuth.GET("/getAll", hanabiController.FindAll)
 	hanabiRouterWithAuth.GET("/getByID/:id", hanabiController.FindByID)
+
+	//commentのエンドポイント
+	commentRouterWithAuth := r.Group("/comment", middlewares.AuthMiddleware(authService))
+	commentRouterWithAuth.POST("/create/:hanabiId", commentController.Create)
 
 	//user認証関連のエンドポイント
 	authRouter := r.Group("/auth")

--- a/reposotories/comment_repository.go
+++ b/reposotories/comment_repository.go
@@ -1,0 +1,27 @@
+package reposotories
+
+import (
+	"gin-fleamarket/models"
+
+	"gorm.io/gorm"
+)
+
+type ICommentRepository interface {
+	Create(newItem models.Comment) (*models.Comment, error)
+}
+
+type CommentRepository struct {
+	db *gorm.DB
+}
+
+func NewCommentMemoryRepository(db *gorm.DB) ICommentRepository {
+	return &CommentRepository{db: db}
+}
+
+func (r *CommentRepository) Create(newComment models.Comment) (*models.Comment, error) {
+	result := r.db.Create(&newComment)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &newComment, nil
+}

--- a/reposotories/hanabi_repository.go
+++ b/reposotories/hanabi_repository.go
@@ -12,6 +12,7 @@ type IHanabiRepository interface {
 	FindByID(hanabiID uint) (*models.Hanabi, error)
 	Create(newItem models.Hanabi) (*models.Hanabi, error)
 	PreloadUser(hanabi *models.Hanabi) error
+	IncrementCommentCount(hanabiId uint) error
 }
 
 type HanabiRepository struct {
@@ -34,14 +35,31 @@ func (r *HanabiRepository) FindAll() (*[]models.Hanabi, error) {
 
 func (r *HanabiRepository) FindByID(hanabiID uint) (*models.Hanabi, error) {
 	var hanabi models.Hanabi
-	result := r.db.Preload("User").First(&hanabi, "id = ?", hanabiID)
+	result := r.db.Preload("User").
+		Preload("Comments").
+		Preload("Comments.User").
+		First(&hanabi, "id = ?", hanabiID)
+
 	if result.Error != nil {
 		if result.Error.Error() == "record not found" {
 			return nil, errors.New("hanabi not found")
 		}
 		return nil, result.Error
 	}
+
+	var commentCount int64
+	result = r.db.Model(&models.Comment{}).Where("hanabi_id = ?", hanabiID).Count(&commentCount)
+	if result.Error != nil {
+		return nil, errors.New("指定されたhanabiのコメントが取得できませんでした")
+	}
+	hanabi.CommentCount = uint(commentCount)
+
 	return &hanabi, nil
+}
+
+// ここに IncrementCommentCount 関数を追加します
+func (r *HanabiRepository) IncrementCommentCount(hanabiId uint) error {
+	return r.db.Model(&models.Hanabi{}).Where("id = ?", hanabiId).Update("comment_count", gorm.Expr("comment_count + ?", 1)).Error
 }
 
 func (r *HanabiRepository) Create(newItem models.Hanabi) (*models.Hanabi, error) {

--- a/services/comment_service.go
+++ b/services/comment_service.go
@@ -1,0 +1,29 @@
+package services
+
+import (
+	"gin-fleamarket/dto"
+	"gin-fleamarket/models"
+	"gin-fleamarket/reposotories"
+)
+
+type ICommentService interface {
+	Create(createCommentInput dto.CreateCommentInput, userId uint, hanabiId uint) (*models.Comment, error)
+}
+
+type CommentService struct {
+	repository reposotories.ICommentRepository
+}
+
+func NewCommentService(repository reposotories.ICommentRepository) ICommentService {
+	return &CommentService{repository: repository}
+}
+
+func (s *CommentService) Create(createCommentInput dto.CreateCommentInput, userId uint, hanabiId uint) (*models.Comment, error) {
+	newComment := models.Comment{
+		Content:  createCommentInput.Content,
+		UserID:   userId,
+		HanabiID: hanabiId,
+	}
+
+	return s.repository.Create(newComment)
+}


### PR DESCRIPTION
hanabiをIDごとに取得するAPIを作成しました。実行すると以下の情報が返されます。
・そのhanabiの写真、イベント名、説明、タグ、コメント数
そしてコメントは配列で返されそのコメントの内容とユーザー名とユーザーアイコンが返されます。

**いいね機能**が未実装となっています。